### PR TITLE
elements無効時のビルド不具合修正

### DIFF
--- a/src/cfdjs_node_addon.cpp
+++ b/src/cfdjs_node_addon.cpp
@@ -315,7 +315,12 @@ Value CreateAddress(const CallbackInfo &information) {
       CreateAddressRequest, CreateAddressResponse, CreateAddressRequestStruct,
       CreateAddressResponseStruct>(
       information, AddressApi::CreateAddress,
-      ElementsAddressApi::CreateAddress);
+#ifndef CFD_DISABLE_ELEMENTS
+      ElementsAddressApi::CreateAddress
+#else
+      AddressApi::CreateAddress
+#endif
+    );
 }
 
 Value CreateMultisig(const CallbackInfo &information) {
@@ -323,7 +328,64 @@ Value CreateMultisig(const CallbackInfo &information) {
       CreateMultisigRequest, CreateMultisigResponse,
       CreateMultisigRequestStruct, CreateMultisigResponseStruct>(
       information, AddressApi::CreateMultisig,
-      ElementsAddressApi::CreateMultisig);
+#ifndef CFD_DISABLE_ELEMENTS
+      ElementsAddressApi::CreateMultisig
+#else
+      AddressApi::CreateMultisig
+#endif
+    );
+}
+
+Value AddSign(const CallbackInfo &information) {
+  return NodeAddonElementsCheckApi<
+      AddSignRequest, AddSignResponse, AddSignRequestStruct,
+      AddSignResponseStruct>(
+      information, TransactionApi::AddSign,
+#ifndef CFD_DISABLE_ELEMENTS
+      ElementsTransactionApi::AddSign
+#else
+      TransactionApi::AddSign
+#endif
+    );
+}
+
+Value UpdateWitnessStack(const CallbackInfo &information) {
+  return NodeAddonElementsCheckApi<
+      UpdateWitnessStackRequest, UpdateWitnessStackResponse,
+      UpdateWitnessStackRequestStruct, UpdateWitnessStackResponseStruct>(
+      information, TransactionApi::UpdateWitnessStack,
+#ifndef CFD_DISABLE_ELEMENTS
+      ElementsTransactionApi::UpdateWitnessStack
+#else
+      TransactionApi::UpdateWitnessStack
+#endif
+    );
+}
+
+Value GetWitnessStackNum(const CallbackInfo &information) {
+  return NodeAddonElementsCheckApi<
+      GetWitnessStackNumRequest, GetWitnessStackNumResponse,
+      GetWitnessStackNumRequestStruct, GetWitnessStackNumResponseStruct>(
+      information, TransactionApi::GetWitnessStackNum,
+#ifndef CFD_DISABLE_ELEMENTS
+      ElementsTransactionApi::GetWitnessStackNum
+#else
+      TransactionApi::GetWitnessStackNum
+#endif
+    );
+}
+
+Value AddMultisigSign(const CallbackInfo &information) {
+  return NodeAddonElementsCheckApi<
+      AddMultisigSignRequest, AddMultisigSignResponse,
+      AddMultisigSignRequestStruct, AddMultisigSignResponseStruct>(
+      information, TransactionApi::AddMultisigSign,
+#ifndef CFD_DISABLE_ELEMENTS
+      ElementsTransactionApi::AddMultisigSign
+#else
+      TransactionApi::AddMultisigSign
+#endif
+    );
 }
 
 Value CreateSignatureHash(const CallbackInfo &information) {
@@ -344,37 +406,6 @@ Value CreateKeyPair(const CallbackInfo &information) {
   return NodeAddonJsonApi<
       CreateKeyPairRequest, CreateKeyPairResponse, CreateKeyPairRequestStruct,
       CreateKeyPairResponseStruct>(information, KeyApi::CreateKeyPair);
-}
-
-Value AddSign(const CallbackInfo &information) {
-  return NodeAddonElementsCheckApi<
-      AddSignRequest, AddSignResponse, AddSignRequestStruct,
-      AddSignResponseStruct>(
-      information, TransactionApi::AddSign, ElementsTransactionApi::AddSign);
-}
-
-Value UpdateWitnessStack(const CallbackInfo &information) {
-  return NodeAddonElementsCheckApi<
-      UpdateWitnessStackRequest, UpdateWitnessStackResponse,
-      UpdateWitnessStackRequestStruct, UpdateWitnessStackResponseStruct>(
-      information, TransactionApi::UpdateWitnessStack,
-      ElementsTransactionApi::UpdateWitnessStack);
-}
-
-Value GetWitnessStackNum(const CallbackInfo &information) {
-  return NodeAddonElementsCheckApi<
-      GetWitnessStackNumRequest, GetWitnessStackNumResponse,
-      GetWitnessStackNumRequestStruct, GetWitnessStackNumResponseStruct>(
-      information, TransactionApi::GetWitnessStackNum,
-      ElementsTransactionApi::GetWitnessStackNum);
-}
-
-Value AddMultisigSign(const CallbackInfo &information) {
-  return NodeAddonElementsCheckApi<
-      AddMultisigSignRequest, AddMultisigSignResponse,
-      AddMultisigSignRequestStruct, AddMultisigSignResponseStruct>(
-      information, TransactionApi::AddMultisigSign,
-      ElementsTransactionApi::AddMultisigSign);
 }
 
 #ifndef CFD_DISABLE_ELEMENTS


### PR DESCRIPTION
## 関連Issue

<!--
このPRが、ZenHubのどのIssueに紐づいているかを記載する
  - ZenHubのURL
-->
- https://app.zenhub.com/workspaces/cfd-5cdbe88f0f84751dcd8fd7ab/issues/cryptogarageinc/btclib-sandbox/823

## 概要

<!--
- 追加機能の概要を記載
- 前提が共有されていない場合は、  
  なぜこの変更をして、  
  どう解決されるのかも併せて記載する

- 必要であれば、以下のような詳細についても記載する
  - 以下の観点で、レビューアーにわかるように技術的な変更点の概要を記載
    - 何をどう変更したか
    - どういった手法を採用したか  
      （e.g. パス探索については、幅優先探索を採用した）
    - 外部システムとのI/F変更
    - など
-->

- cfd-core
  - elements無効ビルド時のテスト不具合修正
    - AbstractTransactionのサイズ取得時、libwallyに空のポインタが渡されていた。
      - テスト用クラスのコンストラクタで空のTransactionを作成してポインタ設定するよう修正。
      - Transactionクラスを使おうと思ったが、Transactionクラスは該当関数をオーバーライドしていたのでabstractの関数は使っていなかった。
    - AddressクラスでElements用のテスト実施時に返却されていたパラメータがカスタム値となっていた。
      - 該当APIの仕様上、Inputに対す居る結果は正しいため、IFDEFでテスト結果判定を切り替えるよう修正。
- cfd-js
  - elements無効ビルド時のビルド不具合修正
    - elementsとbtc共通のAPIで、Elements参照時にクラスが参照できずエラーとなっていた。
    - elements無効時は関数にbtcの関数を設定するよう修正。

## 使い方

<!-- 
- PRの動作確認方法
  - 動作確認が必要なタスクについては、必要なコマンドなどを記載
  - 必要なければ、無記載で良い
-->

```bash
npm run cmake_elem_off
npm run test_all
```

## 今回保留した項目とTODO

<!--
- 箇条書きで保留した項目があれば、記載
  - 保留項目が直近の対応が必要な場合、対応チケットを作成して記載

記載例
- 〇〇の計算ロジックの本実装 #0000
-->

- btc無効ビルドについては今回すっ飛ばした。。
  - 今後もbtc無効ビルドは、オフにした方がいいかも。

## 確認項目

**PRを出した人**
<!-- PRを出す前後で確認する項目 -->

- [ ] チェックスクリプトでチェックを実施した <!-- npm run check -->
- [x] 正常にビルドできた
- [x] 関連チケットに実績をつけた
- [x] ZenHubでPRとIssueを関連付けた
- [x] ZenHubのIssueを `Review/QA` Pipelineに移した

**レビューする人**
<!-- レビューをする前後で確認する項目 -->
- [ ] 関連チケットにレビュー実績をつけた

## 備考

<!--
- 実装に関する悩み（AにするかBにするか迷ったがAにしたや、こうしたかったけどできなかったなど）があれば記載
-->
