### PR TITLE
Feature/refactor test build 20191202

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ endfunction()
 ####################
 # test
 ####################
-if(ENABLE_TESTS)
+if(MSVC OR ENABLE_TESTS)
 enable_testing()
 endif()		# ENABLE_TESTS
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,8 @@ endfunction()
 ####################
 # test
 ####################
-if(MSVC OR ENABLE_TESTS)
+project(cfdjs_all_test CXX)
+if(ENABLE_TESTS)
 enable_testing()
 endif()		# ENABLE_TESTS
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "cmake_compile": "cmake-js compile -O wrap_js/build",
     "cmake_install_configure": "run-script-os",
     "cmake_install_configure:win32": "cmake-js configure -O wrap_js/build --CDENABLE_SHARED=off --CDENABLE_TESTS=off",
-    "cmake_install_configure:linux": "cmake-js configure -O wrap_js/build --CDENABLE_SHARED=off --CDENABLE_TESTS=off --CDTARGET_RPATH=\"./build/Release;./wrap_js/build/Release\" -g",
+    "cmake_install_configure:linux": "cmake-js configure -O wrap_js/build --CDENABLE_SHARED=on --CDENABLE_TESTS=off --CDTARGET_RPATH=\"./build/Release;./wrap_js/build/Release\" -g",
     "cmake_install_configure:darwin": "cmake-js configure -O wrap_js/build --CDENABLE_SHARED=off --CDENABLE_TESTS=off --CDTARGET_RPATH=\"@executable_path;./build/Release;./wrap_js/build/Release\" -C",
     "example": "node wrap_js/example.js",
     "elements_example": "node wrap_js/elements_example.js",


### PR DESCRIPTION
## 関連Issue

<!--
このPRが、ZenHubのどのIssueに紐づいているかを記載する
  - ZenHubのURL
-->
- https://app.zenhub.com/workspaces/cfd-5cdbe88f0f84751dcd8fd7ab/issues/cryptogarageinc/btclib-sandbox/1015
- https://app.zenhub.com/workspaces/cfd-5cdbe88f0f84751dcd8fd7ab/issues/cryptogarageinc/btclib-sandbox/1001
- https://app.zenhub.com/workspaces/cfd-5cdbe88f0f84751dcd8fd7ab/issues/cryptogarageinc/btclib-sandbox/1002
- https://app.zenhub.com/workspaces/cfd-5cdbe88f0f84751dcd8fd7ab/issues/cryptogarageinc/btclib-sandbox/999

## 概要

<!--
- 追加機能の概要を記載
- 前提が共有されていない場合は、  
  なぜこの変更をして、  
  どう解決されるのかも併せて記載する

- 必要であれば、以下のような詳細についても記載する
  - 以下の観点で、レビューアーにわかるように技術的な変更点の概要を記載
    - 何をどう変更したか
    - どういった手法を採用したか  
      （e.g. パス探索については、幅優先探索を採用した）
    - 外部システムとのI/F変更
    - など
-->

- 1015: テスト全体のインストール抑制
  - 全般
  - gtestのinstallオプションを無効にする。
- 1001: MSVC テストビルドOFF時の不具合修正
  - 全般
  - 原因は、ルートにあるCMakeLists.txtのproject指定をtest指定内部に入れていたこと。
    - テスト判定の外部に出すことで、すべて正常に動作するようになった。
- 1002: mingw 32bitビルド時の不具合箇所修正
  - 基本的に無視しようかと思ったが、見つけてしまったので。
  - cfd: feeおよびutxo関連で、size_tの箇所をuint32_tに統一。
- 999: linux環境でのnpm install不具合修正
  - cfd-js: linux環境で、npm install時に作成するものをshared library onlyに変更
- その他
  - cfd-go, sandbox: go testの実施用bat/sh追加

## 使い方

<!-- 
- PRの動作確認方法
  - 動作確認が必要なタスクについては、必要なコマンドなどを記載
  - 必要なければ、無記載で良い
-->

```bash
npm run check_all
npm run cmake_clean
npm run cmake_release (js以外)
npm install (jsのみ)
```

## 今回保留した項目とTODO

<!--
- 箇条書きで保留した項目があれば、記載
  - 保留項目が直近の対応が必要な場合、対応チケットを作成して記載

記載例
- 〇〇の計算ロジックの本実装 #0000
-->

- 

## 確認項目

**PRを出した人**
<!-- PRを出す前後で確認する項目 -->

- [x] チェックスクリプトでチェックを実施した <!-- npm run check -->
- [x] 正常にビルドできた
- [x] 関連チケットに実績をつけた
- [x] ZenHubでPRとIssueを関連付けた
- [x] ZenHubのIssueを `Review/QA` Pipelineに移した

**レビューする人**
<!-- レビューをする前後で確認する項目 -->
- [ ] 関連チケットにレビュー実績をつけた

## 備考

<!--
- 実装に関する悩み（AにするかBにするか迷ったがAにしたや、こうしたかったけどできなかったなど）があれば記載
-->
